### PR TITLE
chore: upgrade `react-date-picker` to v9

### DIFF
--- a/packages/components/elements/calendar/Calendar.tsx
+++ b/packages/components/elements/calendar/Calendar.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { DateRange, DayPicker } from "react-day-picker";
+import { DateRange, DayPicker, type DayPickerProps } from "react-day-picker";
 
 import { cn } from "@util/index";
 
 import { buttonVariants } from "../button";
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+export type CalendarProps = DayPickerProps;
 export type CalendarValueType = {
   single: Date;
   multiple: Date[];
@@ -21,47 +21,53 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("hawa-p-3", className)}
+      className={cn("hawa-p-0", className)}
       classNames={{
-        months:
-          "hawa-flex hawa-flex-col sm:hawa-flex-row hawa-space-y-4 sm:hawa-space-x-4 sm:hawa-space-y-0",
+        root: "hawa-w-fit hawa-relative hawa-p-3 ",
+        months: "hawa-flex hawa-flex-col sm:hawa-flex-row sm:hawa-space-y-0",
         month: "hawa-space-y-4",
-        caption:
-          "hawa-flex hawa-justify-center hawa-pt-1 hawa-relative hawa-items-center",
+        month_caption:
+          "hawa-flex hawa-justify-center hawa-py-1 hawa-relative hawa-items-center",
         caption_label: "hawa-text-sm hawa-font-medium",
-        nav: "hawa-space-x-1 hawa-flex hawa-items-center",
-        nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "hawa-h-7 hawa-w-7 hawa-bg-transparent hawa-p-0 hawa-opacity-50 hover:hawa-opacity-100",
-        ),
-        nav_button_previous:
-          "hawa-absolute hawa-start-1 !hawa-h-8 !hawa-w-8 !hawa-p-0 hawa-justify-center",
-        nav_button_next:
-          "hawa-absolute hawa-end-1 !hawa-h-8 !hawa-w-8 !hawa-p-0 hawa-justify-center",
-        table: "hawa-w-full hawa-border-collapse hawa-space-y-1 ",
-        head_row: "hawa-flex",
-        head_cell:
+        nav: "hawa-z-50 hawa-flex hawa-items-start",
+
+        button_previous: buttonVariants({
+          variant: "outline",
+          className:
+            "hawa-absolute hawa-start-3 hawa-flex hawa-items-center !hawa-size-7 !hawa-p-0 hawa-justify-center",
+        }),
+
+        button_next: buttonVariants({
+          variant: "outline",
+          className:
+            "hawa-absolute hawa-end-3 !hawa-size-7 !hawa-p-0 hawa-justify-center hawa-flex hawa-items-center",
+        }),
+
+        month_grid: "hawa-w-full hawa-border-collapse hawa-space-y-1 ",
+        weekdays: "hawa-flex",
+        weekday:
           "hawa-text-muted-foreground hawa-rounded-md hawa-w-9 hawa-font-normal hawa-text-[0.8rem]",
-        row: "hawa-flex hawa-w-full hawa-mt-2",
-        cell: "hawa-h-9 hawa-w-9 hawa-text-center hawa-text-sm hawa-p-0 hawa-relative [&:has([aria-selected].day-range-end)]:hawa-rounded-r-md [&:has([aria-selected].day-outside)]:hawa-bg-accent/50 [&:has([aria-selected])]:hawa-bg-accent first:[&:has([aria-selected])]:hawa-rounded-l-md last:[&:has([aria-selected])]:hawa-rounded-r-md focus-within:hawa-relative focus-within:hawa-z-20",
-        day: cn(
-          buttonVariants({ variant: "ghost" }),
-          "hawa-h-9 hawa-w-9 hawa-justify-center !hawa-p-0 hawa-font-normal aria-selected:hawa-opacity-100",
-        ),
-        day_range_end: "day-range-end",
-        day_selected:
-          "hawa-bg-primary hawa-text-primary-foreground hover:hawa-bg-primary hover:hawa-text-primary-foreground focus:hawa-bg-primary focus:hawa-text-primary-foreground",
-        day_today: "hawa-bg-accent hawa-text-accent-foreground",
-        day_outside:
+        week: "hawa-flex hawa-w-full hawa-mt-2",
+        day: "hawa-h-9 hawa-w-9 hawa-text-center hawa-text-sm hawa-p-0 hawa-relative [&:has([aria-selected].range-end)]:hawa-rounded-r-md [&:has([aria-selected].outside)]:hawa-bg-accent/50 [&:has([aria-selected])]:hawa-bg-accent first:[&:has([aria-selected])]:hawa-rounded-l-md last:[&:has([aria-selected])]:hawa-rounded-r-md focus-within:hawa-relative focus-within:hawa-z-20",
+        day_button:
+          "hawa-inline-flex hawa-items-center hawa-select-none hawa-rounded-md hawa-text-sm hawa-font-medium hawa-ring-offset-background hawa-transition-colors focus-visible:hawa-outline-none focus-visible:hawa-ring-2 focus-visible:hawa-ring-ring focus-visible:hawa-ring-offset-2 disabled:hawa-pointer-events-none disabled:hawa-opacity-50 hover:hawa-bg-accent hover:hawa-text-accent-foreground hawa-h-9 hawa-w-9 hawa-justify-center !hawa-p-0 aria-selected:hawa-opacity-100 hover:[&:has([aria-selected])]:hawa-bg-red-500",
+
+        selected:
+          "hawa-bg-primary hawa-rounded hawa-text-primary-foreground hover:hawa-bg-primary hover:hawa-text-primary-foreground focus:hawa-bg-primary focus:hawa-text-primary-foreground",
+
+        range_end: "day-range-end",
+
+        today: "hawa-bg-accent hawa-text-accent-foreground hawa-rounded",
+        outside:
           "day-outside hawa-text-muted-foreground hawa-opacity-50 aria-selected:hawa-bg-accent/50 aria-selected:hawa-text-muted-foreground aria-selected:hawa-opacity-30",
-        day_disabled: "hawa-text-muted-foreground hawa-opacity-50",
-        day_range_middle:
+        disabled: "hawa-text-muted-foreground hawa-opacity-50",
+        range_middle:
           "aria-selected:hawa-bg-accent aria-selected:hawa-text-accent-foreground",
-        day_hidden: "hawa-invisible",
+        hidden: "hawa-invisible",
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => (
+        Chevron: (props) => (
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"
@@ -73,23 +79,11 @@ function Calendar({
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-          >
-            <path d="m15 18-6-6 6-6" />
-          </svg>
-        ),
-        IconRight: ({ ...props }) => (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            aria-label="Next Month"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="hawa-rotate-180"
+            className={
+              props.orientation === "right"
+                ? "hawa-rotate-180 hawa-opacity-80"
+                : "hawa-opacity-80"
+            }
           >
             <path d="m15 18-6-6 6-6" />
           </svg>

--- a/packages/components/elements/calendar/Calendar.tsx
+++ b/packages/components/elements/calendar/Calendar.tsx
@@ -3,7 +3,7 @@ import { DateRange, DayPicker, type DayPickerProps } from "react-day-picker";
 
 import { cn } from "@util/index";
 
-import { buttonVariants } from "../button";
+import { Button, buttonVariants } from "../button";
 
 export type CalendarProps = DayPickerProps;
 export type CalendarValueType = {
@@ -48,12 +48,6 @@ function Calendar({
         weekday:
           "hawa-text-muted-foreground hawa-rounded-md hawa-w-9 hawa-font-normal hawa-text-[0.8rem]",
         week: "hawa-flex hawa-w-full hawa-mt-2",
-        day: "hawa-h-9 hawa-w-9 hawa-text-center hawa-text-sm hawa-p-0 hawa-relative [&:has([aria-selected].range-end)]:hawa-rounded-r-md [&:has([aria-selected].outside)]:hawa-bg-accent/50 [&:has([aria-selected])]:hawa-bg-accent first:[&:has([aria-selected])]:hawa-rounded-l-md last:[&:has([aria-selected])]:hawa-rounded-r-md focus-within:hawa-relative focus-within:hawa-z-20",
-        day_button:
-          "hawa-inline-flex hawa-items-center hawa-select-none hawa-rounded-md hawa-text-sm hawa-font-medium hawa-ring-offset-background hawa-transition-colors focus-visible:hawa-outline-none focus-visible:hawa-ring-2 focus-visible:hawa-ring-ring focus-visible:hawa-ring-offset-2 disabled:hawa-pointer-events-none disabled:hawa-opacity-50 hover:hawa-bg-accent hover:hawa-text-accent-foreground hawa-h-9 hawa-w-9 hawa-justify-center !hawa-p-0 aria-selected:hawa-opacity-100 hover:[&:has([aria-selected])]:hawa-bg-red-500",
-
-        selected:
-          "hawa-bg-primary hawa-rounded hawa-text-primary-foreground hover:hawa-bg-primary hover:hawa-text-primary-foreground focus:hawa-bg-primary focus:hawa-text-primary-foreground",
 
         range_end: "day-range-end",
 
@@ -67,6 +61,16 @@ function Calendar({
         ...classNames,
       }}
       components={{
+        DayButton: (props) => (
+          <Button
+            {...props}
+            variant={props.modifiers.selected ? "default" : "ghost"}
+            className="hawa-h-9 hawa-w-9 hawa-text-center hawa-text-sm hawa-p-0 hawa-relative [&:has([aria-selected].range-end)]:hawa-rounded-r-md [&:has([aria-selected].outside)]:hawa-bg-accent/50 [&:has([aria-selected])]:hawa-bg-accent first:[&:has([aria-selected])]:hawa-rounded-l-md last:[&:has([aria-selected])]:hawa-rounded-r-md focus-within:hawa-relative focus-within:hawa-z-20"
+          >
+            {props.children}
+          </Button>
+        ),
+
         Chevron: (props) => (
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/elements/datePicker/DatePicker.tsx
+++ b/packages/components/elements/datePicker/DatePicker.tsx
@@ -18,7 +18,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   trigger,
   popoverTriggerProps,
   popoverContentProps,
-  required,
+  // required,
   ...props
 }) => {
   return (
@@ -26,7 +26,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
       <PopoverTrigger {...popoverTriggerProps}>{trigger}</PopoverTrigger>
       <PopoverContent
         align={props.dir === "rtl" ? "end" : "start"}
-        sideOffset={required ? -16 : -4}
+        // sideOffset={required ? -16 : -4}
         {...popoverContentProps}
       >
         <Calendar {...props} />

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sikka/hawa",
-  "version": "0.42.11",
+  "version": "0.42.12",
   "description": "Modern UI Kit made with Tailwind",
   "author": {
     "name": "Sikka Software",
@@ -86,7 +86,7 @@
     "libphonenumber-js": "^1.11.4",
     "prism-react-renderer": "^2.3.1",
     "prismjs": "^1.29.0",
-    "react-day-picker": "^8.10.1",
+    "react-day-picker": "^9.0.1",
     "react-dropzone": "^14.2.3",
     "react-headless-pagination": "^1.1.6",
     "react-hook-form": "^7.52.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-day-picker:
-        specifier: ^8.10.1
-        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+        specifier: ^9.0.1
+        version: 9.0.1(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -382,8 +382,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
       react-day-picker:
-        specifier: ^8.10.1
-        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+        specifier: ^9.0.1
+        version: 9.0.1(react@18.3.1)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -7502,11 +7502,10 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-day-picker@8.10.1:
-    resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
+  react-day-picker@9.0.1:
+    resolution: {integrity: sha512-BVpvpt1OLsDNy6rYK/lD+ruXMqTiYRWioR32jJ/zhBODT5KCoMVr2IcbISJBQWKnMRicDxFhb8ijW32yE2MSYg==}
     peerDependencies:
-      date-fns: ^2.28.0 || ^3.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: '>=16.8.0'
 
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -14070,7 +14069,7 @@ snapshots:
       eslint: 9.7.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@9.7.0))(eslint@9.7.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.7.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@9.7.0))(eslint@9.7.0))(eslint@9.7.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.7.0)
       eslint-plugin-react: 7.33.2(eslint@9.7.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@9.7.0)
@@ -14094,7 +14093,7 @@ snapshots:
       enhanced-resolve: 5.15.0
       eslint: 9.7.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@9.7.0))(eslint@9.7.0))(eslint@9.7.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.7.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@9.7.0))(eslint@9.7.0))(eslint@9.7.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -14116,7 +14115,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.7.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.18.1(eslint@9.7.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@9.7.0))(eslint@9.7.0))(eslint@9.7.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -17084,7 +17083,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
+  react-day-picker@9.0.1(react@18.3.1):
     dependencies:
       date-fns: 3.6.0
       react: 18.3.1


### PR DESCRIPTION
Migration complete except for the hover styles on `selected` className. It seems the hover tailwind classes of the `day_button` overwrite the hover tailwind classes of `selected`

![rdp-selected-day-hover](https://github.com/user-attachments/assets/c9d6dc81-3e11-42a0-be28-d19075342b9c)
